### PR TITLE
Wrong Chocolatey install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ scoop bucket add extras
 scoop install mpv.net
 ```
 Alternatively, Chocolatey can also be used
-`choco install mpv.net`
+`choco install mpvnet.install`


### PR DESCRIPTION
I am really sorry. I mostly use scoop and not much Chocolatey. The correct command is `choco install mpvnet.install`