### PR TITLE
Updated download link for stable build

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -119,7 +119,7 @@ Download
 
 ### Stable
 
-[Release page](releases)
+[Release page](https://github.com/stax76/mpv.net/releases)
 
 
 ### Beta


### PR DESCRIPTION
I noticed that the download link for the stable build was redirecting to a 404 so I replaced the link with https://github.com/stax76/mpv.net/releases

The old link that was giving the 404 error was https://github.com/stax76/mpv.net/blob/master/releases