### PR TITLE
Manual.md : Remove Chocolatey and Appget

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -142,20 +142,12 @@ x64 editions have the advantage of being typically better optimized and tested.
 
 ### Scoop
 
+If you use Scoop
+
 ```
 scoop bucket add extras
 scoop install mpv.net
 ```
-
-
-### AppGet
-
-`appget install mpv-net`
-
-
-### Chocolatey
-
-`choco install mpvnet.install`
 
 
 #### File Associations


### PR DESCRIPTION
Although Scoop updates to latest version within hours, both Chocolatey and Appget are outdated
https://chocolatey.org/packages/mpvnet.install
https://appget.net/packages/i/mpv-net
Not to mention
https://github.com/appget/appget.packages/issues/5337