### PR TITLE
fix for #124

### DIFF
--- a/mpv.net/WinForms/MainForm.cs
+++ b/mpv.net/WinForms/MainForm.cs
@@ -537,6 +537,7 @@ namespace mpvnet
                 case 0x101: // WM_KEYUP
                 case 0x104: // WM_SYSKEYDOWN
                 case 0x105: // WM_SYSKEYUP
+                case 0x20e: // WM_MOUSEHWHEEL fix for #124
                     {
                         bool skip = m.Msg == 0x100 && LastAppCommand != 0 &&
                             (Environment.TickCount - LastAppCommand) < 1000;


### PR DESCRIPTION
> according to my test with my g502 and [List Of Windows Messages](https://wiki.winehq.org/List_Of_Windows_Messages)

wheel_left and wheel_right still can't be detected in `Learn Input` window.

Since those case only forwarding `m` to mpv, why not put them in `default case`
