### PR TITLE
removed value check

### DIFF
--- a/src/Misc/GlobalHotkey.cs
+++ b/src/Misc/GlobalHotkey.cs
@@ -61,9 +61,6 @@ namespace mpvnet
                 int hi = result >> 8;
                 int lo = result & 0xFF;
 
-                if (lo == -1)
-                    return;
-
                 vk = lo;
 
                 if ((hi & 1) == 1) mod |= KeyModifiers.Shift;


### PR DESCRIPTION
`short result = VkKeyScanEx(key[0], GetKeyboardLayout(0));
int lo = result & 0xFF;`

Variable `lo` will never be -1.

I removed this check
`if (lo == -1)`