### PR TITLE
Add ability to target .NET 5.0

### DIFF
--- a/src/Extensions/RatingExtension/RatingExtension.csproj
+++ b/src/Extensions/RatingExtension/RatingExtension.csproj
@@ -1,63 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{55C88710-539D-4402-84C8-31694841C731}</ProjectGuid>
+    <TargetFrameworks>net48</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>RatingExtension</RootNamespace>
-    <AssemblyName>RatingExtension</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.CSharp" Version="1.0.0" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+	<ProjectReference Include="..\..\mpv.net.csproj">
+		<SetTargetFramework>TargetFramework=net48</SetTargetFramework>
+	</ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="RatingExtension.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ScriptDevelopment.cs" />
+  <ItemGroup Condition=" '$(TargetFramework)' == '.net5.0-windows' ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+	<ProjectReference Include="..\..\mpv.net.csproj">
+		<SetTargetFramework>TargetFramework=.net5.0-windows</SetTargetFramework>
+	</ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\mpv.net.csproj">
-      <Project>{1751f378-8edf-4b62-be6d-304c7c287089}</Project>
-      <Name>mpv.net</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -114,9 +114,6 @@ namespace mpvnet.Properties {
         ///osd-playing-msg = &apos;${filename}&apos;
         ///script-opts = osc-scalewindowed=1.5,osc-hidetimeout=2000,console-scale=1
         ///screenshot-directory = &apos;~~desktop/&apos;
-        ///
-        ///[protocol.https]
-        ///osd-playing-msg = &apos;${media-title}&apos;
         ///.
         /// </summary>
         internal static string mpv_conf {
@@ -132,6 +129,16 @@ namespace mpvnet.Properties {
             get {
                 object obj = ResourceManager.GetObject("mpvnet", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
+        /// </summary>
+        internal static System.Drawing.Icon mpvnet_icon {
+            get {
+                object obj = ResourceManager.GetObject("mpvnet_icon", resourceCulture);
+                return ((System.Drawing.Icon)(obj));
             }
         }
         

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -127,6 +127,9 @@
   <data name="mpvnet" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\mpvnet.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="mpvnet_icon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\mpvnet.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="mpvnet_santa" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\mpvnet-santa.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/src/WinForms/MainForm.Designer.cs
+++ b/src/WinForms/MainForm.Designer.cs
@@ -52,7 +52,9 @@
             this.BackColor = System.Drawing.Color.Black;
             this.ClientSize = new System.Drawing.Size(348, 0);
             this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            // the below line was causing mpv.net to crash for the .net 4.8 build once migrated to the new sdk-style csproj.
+            //this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Icon = Properties.Resources.mpvnet_icon;
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/mpv.net.csproj
+++ b/src/mpv.net.csproj
@@ -1,241 +1,73 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1751F378-8EDF-4B62-BE6D-304C7C287089}</ProjectGuid>
+    <TargetFrameworks>net48</TargetFrameworks>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>mpvnet</RootNamespace>
     <AssemblyName>mpvnet</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <OutputPath>bin\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup />
-  <PropertyGroup />
   <PropertyGroup>
     <StartupObject>mpvnet.Program</StartupObject>
   </PropertyGroup>
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
-  <PropertyGroup />
   <PropertyGroup>
     <ApplicationIcon>mpvnet.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="WindowsFormsIntegration" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Misc\App.cs" />
-    <Compile Include="Misc\Common.cs" />
-    <Compile Include="WPF\RelayCommand.cs" />
-    <Compile Include="Misc\CSharpScriptHost.cs" />
-    <Compile Include="Misc\Extension.cs" />
     <None Include="..\docs\Changelog.md">
       <Link>Changelog.md</Link>
     </None>
     <None Include="..\docs\Manual.md">
       <Link>Manual.md</Link>
     </None>
-    <None Include="Resources\mpvnet-santa.png" />
-    <None Include="Resources\editor_conf.txt" />
     <Content Include="Resources\theme.txt" />
-    <Page Include="WPF\CommandPaletteControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="WPF\SearchTextBoxUserControl.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\SetupWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\AboutWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\Resources.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Compile Include="Misc\Global.cs" />
-    <Compile Include="Misc\Help.cs" />
-    <Compile Include="Misc\GlobalHotkey.cs" />
-    <Compile Include="Misc\Msg.cs" />
-    <Compile Include="Misc\Settings.cs" />
-    <Compile Include="Misc\Terminal.cs" />
-    <Compile Include="Misc\UpdateCheck.cs" />
-    <Compile Include="Misc\Theme.cs" />
-    <Compile Include="Misc\PowerShell.cs" />
-    <Compile Include="Native\StockIcon.cs" />
-    <Compile Include="WPF\CommandPaletteControl.xaml.cs">
-      <DependentUpon>CommandPaletteControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\SearchTextBoxUserControl.xaml.cs">
-      <DependentUpon>SearchTextBoxUserControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Misc\Conf.cs" />
-    <Compile Include="WPF\OptionSettingControl.xaml.cs">
-      <DependentUpon>OptionSettingControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\StringSettingControl.xaml.cs">
-      <DependentUpon>StringSettingControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Misc\ExtensionMethods.cs" />
-    <Compile Include="Native\MediaInfo.cs" />
-    <Compile Include="Native\Taskbar.cs" />
-    <Compile Include="WinForms\Menu.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
+    <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Native\libmpv.cs" />
-    <Compile Include="WinForms\MainForm.cs">
-      <SubType>Form</SubType>
+    <Compile Update="WinForms\Menu.cs">
+      <SubType>Component</SubType>
     </Compile>
-    <Compile Include="WinForms\MainForm.Designer.cs">
-      <DependentUpon>MainForm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Misc\Misc.cs" />
-    <Compile Include="Misc\CorePlayer.cs" />
-    <Compile Include="Misc\Commands.cs" />
-    <Compile Include="Native\Native.cs" />
-    <Compile Include="Misc\Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="WPF\SetupWindow.xaml.cs">
-      <DependentUpon>SetupWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\ConfWindow.xaml.cs">
-      <DependentUpon>ConfWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\AboutWindow.xaml.cs">
-      <DependentUpon>AboutWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\LearnWindow.xaml.cs">
-      <DependentUpon>LearnWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\InputWindow.xaml.cs">
-      <DependentUpon>InputWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="WPF\WPF.cs" />
-    <EmbeddedResource Include="WinForms\MainForm.resx">
-      <DependentUpon>MainForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
     <None Include="..\README.md">
       <Link>README.md</Link>
     </None>
-    <None Include="app.manifest" />
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
     <Content Include="mpvnet.ico" />
     <Content Include="Resources\mpv.conf.txt" />
-    <None Include="Resources\mpvnet.ico" />
-    <None Include="Resources\mpvnet.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\input.conf.txt" />
   </ItemGroup>
-  <ItemGroup>
-    <Page Include="WPF\OptionSettingControl.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\StringSettingControl.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\ConfWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\LearnWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="WPF\InputWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup Condition=" '$(TargetFramework)' == '.net5.0-windows' ">
+    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.1.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Extensions\RatingExtension\Properties\AssemblyInfo.cs" />
+    <Compile Remove="Extensions\RatingExtension\RatingExtension.cs" />
+    <Compile Remove="Extensions\RatingExtension\ScriptDevelopment.cs" />
+    <Compile Remove="Scripts\C-Sharp\delete-current-file.cs" />
+    <Compile Remove="Scripts\C-Sharp\key-binding.cs" />
+    <Compile Remove="Scripts\C-Sharp\observe-property-and-draw-text.cs" />
+    <Compile Remove="Scripts\C-Sharp\pause-when-minimize.cs" />
+    <Compile Remove="Scripts\C-Sharp\rate-file.cs" />
+    <Compile Remove="Scripts\C-Sharp\switch-profile-context-menu.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
I have converted the csproj files to the new sdk-style format and added the ability to target .net5.0-windows. After converting the csproj files the .NET 4.8 build of mpv was crashing on start up when trying to reference the icon so I have embedded the icon into the resource file and changed how the icon is referenced.

You can target .net 5.0-windows by modifying the TargetFrameworks property for each csproj file:
`<TargetFrameworks>net48;.net5.0-windows</TargetFrameworks>`