### PR TITLE
fix a potential bug when switching back to `auto`

### DIFF
--- a/src/Resources/editor_conf.txt
+++ b/src/Resources/editor_conf.txt
@@ -108,11 +108,10 @@ option = oversample        A version of nearest neighbour that (naively) oversam
 [setting]
 name = dscale
 file = mpv
-default = auto
+default = 
 filter = Video
-help = Like scale, but apply these filters on downscaling instead.
+help = Like scale, but apply these filters on downscaling instead. \nIf no option is selected, it will keep the same with the upscaler.
 
-option = auto              Same with the upscaler.
 option = bilinear          Bilinear hardware texture filtering (fastest, very low quality).
 option = spline36          Mid quality and speed. This is the default when using gpu-hq.
 option = lanczos           Lanczos scaling. Provides mid quality and speed. Generally worse than spline36, but it results in a slightly sharper image which is good for some content types. The number of taps can be controlled with  scale-radius, but is best left unchanged. (This filter is an alias for sinc-windowed sinc)


### PR DESCRIPTION
Now many of editor's option will be applied at runtime, so the previous solution may cause the problem if users select another downscaler first and then switch back to `auto`. So I delete the option `auto` and make the default empty, which still makes it follow the original mpv's behaviour.