### PR TITLE
Add two new keybinds for controlling volume

### DIFF
--- a/src/Resources/input.conf.txt
+++ b/src/Resources/input.conf.txt
@@ -94,6 +94,8 @@ _           ignore                 #menu: Track
 
 +           add volume  2          #menu: Volume > Up
 -           add volume -2          #menu: Volume > Down
+0           add volume  2          #menu: Volume > Up
+9           add volume -2          #menu: Volume > Down
 _           ignore                 #menu: Volume > -
 m           cycle mute             #menu: Volume > Mute
 


### PR DESCRIPTION
This keybinds is used in mpv, - + are intuitive for controlling volume, but i have compact keyboard without numpad, and pressing + in number row requires me to press it with shift, which i want to avoid.

https://github.com/mpv-player/mpv/blob/master/etc/input.conf#L103-L105